### PR TITLE
Updated Windows docker and podman image run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,13 @@ docker run -it --name nia -v "{$PWD}:/var/nia" nia
 
 The image can be built using the following command:
 
-```sh
-$ podman build --tag nia .
-```
+
 
 Run the image using
 
 #### Linux $PWD
 ```sh
+$ podman build --tag nia .
 ```
 
 #### Windows ($PWD)

--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ $ docker build --tag nia .
 
 Run the image using
 
+#### Linux $PWD
 ```sh
 docker run -it --name nia -v "$PWD:/var/nia" nia
+```
+
+#### Windows {$PWD}
+Run the image using Powershell and {$PWD} due to $PWD not being avaliable in command prompt on Windows.
+```sh
+docker run -it --name nia -v "{$PWD}:/var/nia" nia
 ```
 
 ### Podman
@@ -33,9 +40,17 @@ $ podman build --tag nia .
 
 Run the image using
 
+#### Linux $PWD
 ```sh
-podman run -it --name nia -v "$PWD:/var/nia" nia
 ```
+
+#### Windows ($PWD)
+Run the image using Powershell and {$PWD} due to $PWD not being avaliable in command prompt on Windows.
+```sh
+podman run -it --name nia -v "{$PWD}:/var/nia" nia
+```
+
+
 
 ## Disclaimer
 


### PR DESCRIPTION
Updated command for running docker container in Windows. Windows uses {$PWD} vs $PWS on Linux.